### PR TITLE
Fix CLI helpers

### DIFF
--- a/kairose-lang/runtime/semantic_layer.py
+++ b/kairose-lang/runtime/semantic_layer.py
@@ -16,3 +16,22 @@ class IntentBlock:
     source_text: str           # 원문 자연어 문장
     origin_eid: Optional[str] = None  # .eid에서 상속된 정체성 기반 실행
     confidence: float = 1.0    # 해석 신뢰도
+
+
+def to_kairose_code(block: IntentBlock) -> str:
+    """Convert an ``IntentBlock`` to a snippet of Kairose code."""
+
+    if block.intent == "remember" and block.emotion:
+        lines = [f"  {k}: {v}" for k, v in block.emotion.items()]
+        return "remember {\n" + "\n".join(lines) + "\n}"
+
+    if block.intent == "execute" and block.target:
+        return f"leak {block.target}"
+
+    if block.intent == "link" and block.target:
+        return f"link {block.target}"
+
+    if block.intent == "trace":
+        return "trace session"
+
+    return f"# unknown intent: {block.intent}"


### PR DESCRIPTION
## Summary
- implement `to_kairose_code` in the semantic layer
- add `execute_intent_block` helper to runtime
- wire imports for CLI execution

## Testing
- `python -m py_compile kairose-lang/runtime/semantic_layer.py kairose-lang/runtime/leak_runtime.py`

------
https://chatgpt.com/codex/tasks/task_e_6839618ed060832e977f3fe2b7279009